### PR TITLE
Karamelfile changes to support SSL

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,7 +13,7 @@ provisioner:
   name: chef_solo
 
 platforms:
-  - name: ubuntu-14.04
+  - name: ubuntu-16.04
 #  - name: centos-7.0
 #  - name: ubuntu-15.04
 
@@ -24,8 +24,7 @@ suites:
   - name: default
     run_list:
       - recipe[kagent::install]
-      - recipe[kagent::anaconda]
-      #- recipe[kagent::default]
+      - recipe[kagent::default]
     attributes:
          kagent:
             test: true

--- a/Karamelfile
+++ b/Karamelfile
@@ -3,7 +3,3 @@ dependencies:
     global:  
       - hopsworks::default
       - hopsworks::dev
-      - kafka::default
-      - epipe::default
-      - livy::default
-      - drelephant::default

--- a/Karamelfile
+++ b/Karamelfile
@@ -2,6 +2,7 @@ dependencies:
   - recipe: kagent::default
     global:  
       - hopsworks::default
+      - hopsworks::dev
       - kafka::default
       - epipe::default
       - livy::default

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,7 +20,7 @@ default.kagent.enabled                     = "true"
 default.kagent.certs_dir                   = "#{node.kagent.dir}/kagent-certs"
 
 # API calls
-default.kagent.dashboard.api.register      = "/api/agentservice/register"
+default.kagent.dashboard.api.register      = "/ca/agentservice/register"
 default.kagent.dashboard.api.login         = "/api/auth/login"
 default.kagent.dashboard.api.heartbeat     = "/api/agentresource/heartbeat"
 default.kagent.dashboard.api.alert         = "/api/agentresource/alert"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,10 +20,10 @@ default["kagent"]["enabled"]                       = "true"
 default["kagent"]["certs_dir"]                     = "#{node["kagent"]["dir"]}/kagent-certs"
 
 # API calls
-default["kagent"]["dashboard"]["api"]["register"]  = "/ca/agentservice/register"
-default["kagent"]["dashboard"]["api"]["login"]     = "/api/auth/login"
-default["kagent"]["dashboard"]["api"]["heartbeat"] = "/api/agentresource/heartbeat"
-default["kagent"]["dashboard"]["api"]["alert"]     = "/api/agentresource/alert"
+default["kagent"]["dashboard"]["api"]["register"]  = "ca/agentservice/register"
+default["kagent"]["dashboard"]["api"]["login"]     = "api/auth/login"
+default["kagent"]["dashboard"]["api"]["heartbeat"] = "api/agentresource/heartbeat"
+default["kagent"]["dashboard"]["api"]["alert"]     = "api/agentresource/alert"
 
 # Username/Password for the dashboard connecting to Hopsworks
 default["kagent"]["dashboard"]["user"]             = "agent@hops.io"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,108 +1,107 @@
-default.install.dir                        = ""
-default.install.user                       = ""
+default["install"]["dir"]                          = ""
+default["install"]["user"]                         = ""
 
 # Default values for configuration parameters
-default.kagent.version                     = "0.1.0"
-default.kagent.user                        = node.install.user.empty? ? "kagent" : node.install.user
-default.kagent.group                       = node.install.user.empty? ? "kagent" : node.install.user
-default.kagent.certs_group                 = "certs"
+default["kagent"]["version"]                       = "0.1.0"
+default["kagent"]["user"]                          = node["install"]["user"].empty? ? "kagent" : node["install"]["user"]
+default["kagent"]["group"]                         = node["install"]["user"].empty? ? "kagent" : node["install"]["user"]
+default["kagent"]["certs_group"]                   = "certs"
 
 
-default.kagent.dir                         = node.install.dir.empty? ? "/var/lib" : node.install.dir
-default.kagent.base_dir                    = "#{node.kagent.dir}/kagent"
-default.kagent.home                        = "#{node.kagent.dir}/kagent-#{node.kagent.version}"
-default.kagent.conda_enabled               = "true"
+default["kagent"]["dir"]                           = node["install"]["dir"].empty? ? "/var/lib" : node["install"]["dir"]
+default["kagent"]["base_dir"]                      = "#{node["kagent"]["dir"]}/kagent"
+default["kagent"]["home"]                          = "#{node["kagent"]["dir"]}/kagent-#{node["kagent"]["version"]}"
+default["kagent"]["conda_enabled"]                 = "true"
 
-default.conda.default_libs                 = %w{ numpy hdfs3 scikit-learn matplotlib pandas tensorflow }
+default["conda"]["default_libs"]                   = %w{ numpy hdfs3 scikit-learn matplotlib pandas tensorflow }
 
-default.kagent.enabled                     = "true"
+default["kagent"]["enabled"]                       = "true"
 
-default.kagent.certs_dir                   = "#{node.kagent.dir}/kagent-certs"
+default["kagent"]["certs_dir"]                     = "#{node["kagent"]["dir"]}/kagent-certs"
 
 # API calls
-default.kagent.dashboard.api.register      = "/ca/agentservice/register"
-default.kagent.dashboard.api.login         = "/api/auth/login"
-default.kagent.dashboard.api.heartbeat     = "/api/agentresource/heartbeat"
-default.kagent.dashboard.api.alert         = "/api/agentresource/alert"
+default["kagent"]["dashboard"]["api"]["register"]  = "/ca/agentservice/register"
+default["kagent"]["dashboard"]["api"]["login"]     = "/api/auth/login"
+default["kagent"]["dashboard"]["api"]["heartbeat"] = "/api/agentresource/heartbeat"
+default["kagent"]["dashboard"]["api"]["alert"]     = "/api/agentresource/alert"
 
 # Username/Password for the dashboard connecting to Hopsworks
-default.kagent.dashboard.user              = "agent@hops.io"
-default.kagent.dashboard.password          = "admin"
+default["kagent"]["dashboard"]["user"]             = "agent@hops.io"
+default["kagent"]["dashboard"]["password"]         = "admin"
 
 # Username/Password for the keystore
 
-default.hopsworks.master.password          = "adminpw"
+default["hopsworks"]["master"]["password"]         = "adminpw"
 
 # Agent's local certificate for SSL connections
-default.kagent.certificate_file            = "server.pem"
+default["kagent"]["certificate_file"]              = "server.pem"
 
 # dashboard ip:port endpoint
-default.kagent.dashboard.ip                = "10.0.2.15"
-default.kagent.dashboard.port              = "8080"  
-default.kagent.dashboard_app               = "hopsworks-api"
-default.kagent.ca_app                      = "hopsworks-ca"
+default["kagent"]["dashboard"]["ip"]               = "10.0.2.15"
+default["kagent"]["dashboard"]["port"]             = "8080"  
+default["kagent"]["dashboard_app"]                 = "hopsworks-api"
+default["kagent"]["ca_app"]                        = "hopsworks-ca"
 
 # local settings for agent
-default.kagent.port                        = 8090
-default.kagent.heartbeat_interval          = 3
-default.kagent.watch_interval              = 2
-default.kagent.pid_file                    = node.kagent.base_dir + "/kagent.pid"
-default.kagent.logging_level               = "INFO"
-default.kagent.max_log_size                = "10000000"
-default.kagent.env_report_freq_in_secs     = "10"
+default["kagent"]["port"]                          = 8090
+default["kagent"]["heartbeat_interval"]            = 3
+default["kagent"]["watch_interval"]                = 2
+default["kagent"]["pid_file"]                      = node["kagent"]["base_dir"] + "/kagent.pid"
+default["kagent"]["logging_level"]                 = "INFO"
+default["kagent"]["max_log_size"]                  = "10000000"
+default["kagent"]["env_report_freq_in_secs"]       = "10"
 
-default.kagent.network.interface           = ""
+default["kagent"]["network"]["interface"]          = ""
 
-default.kagent[:default][:public_ips]      = ['10.0.2.15']
-default.kagent[:default][:private_ips]     = ['10.0.2.15']
+default["kagent"][:default][:public_ips]              = ['10.0.2.15']
+default["kagent"][:default][:private_ips]             = ['10.0.2.15']
 
 # services file contains locally installed services
 
-default.kagent.services                    = node.kagent.base_dir + "/services"
+default["kagent"]["services"]                      = node["kagent"]["base_dir"] + "/services"
 
 # name of cluster as shown in Dashboard
-default.kagent.cluster                     = "Hops"
+default["kagent"]["cluster"]                       = "Hops"
 
-default.kagent.hostid                      = 100
+default["kagent"]["hostid"]                        = 100
 
-default.kagent.hostname                    =
+default["kagent"]["hostname"]                      =
 
-default.kagent.keystore_dir 		   = node.kagent.certs_dir + "/keystores"
+default["kagent"]["keystore_dir"] 		   = node["kagent"]["certs_dir"] + "/keystores"
 
-default.public_ips                         = ['10.0.2.15']
-default.private_ips                        = ['10.0.2.15']
-default.kagent.allow_ssh_access            = "false"
+default["public_ips"]                              = ['10.0.2.15']
+default["private_ips"]                             = ['10.0.2.15']
+default["kagent"]["allow_ssh_access"]              = "false"
 
-node.default.download_url                  = "http://193.10.67.171/hops"
-node.default.systemd                       = "true"
-node.default.ndb.mysql_socket              = "/tmp/mysql.sock"
-node.default.ndb.mysql.jdbc_url            = ""
-node.default.ndb.mysql_port                = "3306"
+node.default["download_url"]                       = "http://193.10.67.171/hops"
+node.default["systemd"]                            = "true"
+node.default["ndb"]["mysql_socket"]                = "/tmp/mysql.sock"
+node.default["ndb"]["mysql.jdbc_url"]              = ""
+node.default["ndb"]["mysql_port"]                  = "3306"
 
-node.default.vagrant                       = "false"
+node.default["vagrant"]                            = "false"
 
-node.default.ntp.install                   = "false"
+node.default["ntp"]["install"]                     = "false"
 # Servers to sync ntp time with
 # '0.pool.ntp.org', '1.pool.ntp.org'
-node.normal.ntp.servers                    = ['0.europe.pool.ntp.org', '1.europe.pool.ntp.org', '2.europe.pool.ntp.org', '3.europe.pool.ntp.org']
+node.normal["ntp"]["servers"]                      = ['0.europe.pool.ntp.org', '1.europe.pool.ntp.org', '2.europe.pool.ntp.org', '3.europe.pool.ntp.org']
 
-node.normal.ntp.peers                      = ['time0.int.example.org', 'time1.int.example.org']
+node.normal["ntp"]["peers"]                        = ['time0.int.example.org', 'time1.int.example.org']
 
-default.kagent.test                        = false
-
-
-default.kagent.keystore                    = "#{node.kagent.base_dir}/node_server_keystore.jks"
-default.kagent.keystore_password           = "changeit"
+default["kagent"]["test"]                          = false
 
 
-default.smtp.host                          = "smtp.gmail.com"
-default.smtp.port                          = "587"
-default.smtp.ssl_port                      = "465"
-default.smtp.email                         = "smtp@gmail.com"
-default.smtp.email_password                = "password"
-default.smtp.gmail.placeholder             = "http://snurran.sics.se/hops/hopsworks.email"
+default["kagent"]["keystore"]                      = "#{node["kagent"]["base_dir"]}/node_server_keystore.jks"
+default["kagent"]["keystore_password"]             = "changeit"
 
 
-default.services.enabled                   = "true"
+default["smtp"]["host"]                            = "smtp.gmail.com"
+default["smtp"]["port"]                            = "587"
+default["smtp"]["ssl_port"]                        = "465"
+default["smtp"]["email"]                           = "smtp@gmail.com"
+default["smtp"]["email_password"]                  = "password"
+default["smtp"]["gmail.placeholder"]               = "http://snurran.sics.se/hops/hopsworks.email"
 
+
+default["services"]["enabled"]                     = ""
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -40,7 +40,7 @@ default.kagent.certificate_file            = "server.pem"
 default.kagent.dashboard.ip                = "10.0.2.15"
 default.kagent.dashboard.port              = "8080"  
 default.kagent.dashboard_app               = "hopsworks-api"
-
+default.kagent.ca_app                      = "hopsworks-ca"
 
 # local settings for agent
 default.kagent.port                        = 8090

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -8,17 +8,17 @@ require 'resolv'
 module Kagent 
   module Helpers  
     def my_public_ip()
-      node.public_ips[0]
+      node["public_ips"][0]
     end
 
     def my_dns_name()
-      node.public_ips[0]
+      node["public_ips"][0]
       return dns_lookup(ip)
     end
 
 
     def my_private_ip()
-      node.private_ips[0]
+      node["private_ips"][0]
     end
 
     def valid_cookbook(cookbook)
@@ -67,7 +67,7 @@ module Kagent
           begin
             h = dns.getname("#{host}")
           rescue
-            if (node.vagrant)
+            if (node["vagrant"])
               # gsub() returns a copy of the modified str with replacements
               # gsub!() makes the replacements in-place
               # hostName = host.gsub("\.","_")
@@ -93,7 +93,7 @@ module Kagent
       my_ip = my_private_ip()
       my_dns_name = my_dns_name()
       hostsfile_entry "#{my_ip}" do
-        hostname  node.fqdn
+        hostname  node["fqdn"]
         unique    true
         action    :append
       end
@@ -152,12 +152,12 @@ module Kagent
     
     def ndb_connectstring()
       connectString = ""
-      for n in node.ndb.mgmd.private_ips
-        connectString += "#{n}:#{node.ndb.mgmd.port},"
+      for n in node["ndb"]["mgmd"]["private_ips"]
+        connectString += "#{n}:#{node["ndb"]["mgmd"]["port"]},"
       end
       # Remove the last ','
       connectString = connectString.chop
-      node.normal.ndb.connectstring = connectString
+      node.normal["ndb"]["connectstring"] = connectString
     end
     
     def jdbc_url()
@@ -165,13 +165,13 @@ module Kagent
       # On failure, contact other mysqlds. We should configure
       # the mysqlconnector to use the first localhost and only failover
       # to other mysqlds
-      jdbcUrl = "localhost:#{node.ndb.mysql_port},"
-      for n in node.ndb.mysqld.private_ips
+      jdbcUrl = "localhost:#{node["ndb"]["mysql_port"]},"
+      for n in node["ndb"]["mysqld"]["private_ips"]
         fqdn = dns_lookup(n)
-        jdbcUrl += "#{fqdn}:#{node.ndb.mysql_port},"
+        jdbcUrl += "#{fqdn}:#{node["ndb"]["mysql_port"]},"
       end
       jdbcUrl = jdbcUrl.chop
-      node.normal.ndb.mysql.jdbc_url = "jdbc:mysql://" + jdbcUrl + "/"
+      node.normal["ndb"]["mysql"]["jdbc_url"] = "jdbc:mysql://" + jdbcUrl + "/"
     end
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -73,7 +73,7 @@ attribute "kagent/dashboard/user",
           :type => "string"
 
 attribute "kagent/hostname",
-          :description => "hostname to register with server",
+          :description => "hostname used to register with hopsworks",
           :type => "string"
 
 attribute "kagent/dashboard/password",

--- a/providers/conda.rb
+++ b/providers/conda.rb
@@ -1,43 +1,32 @@
 action :config do
 
-# This is the hopsworks-wide default environment that all projects will clone their environment from.
-#   #{node.conda.base_dir}/bin/conda create -n hopsworksconda -y -q 
-# --file #{node.kagent.base_dir}/anaconda/spec-file.txt
-
-# execute "change_owner_to_kagent" do
-#   user "root"
-#   command "chown -R #{node.kagent.user}:#{node.kagent.group} #{node.conda.home}"
-# end
-
-
-  
- execute "update_conda" do
+  execute "update_conda" do
    user "root"
-   command "su #{node.conda.user} -c \"#{node.conda.base_dir}/bin/conda update conda -y -q\""
+   command "su #{node["conda"]["user"]} -c \"#{node["conda"]["base_dir"]}/bin/conda update conda -y -q\""
  end
 
  execute "update_anconda" do
    user "root"
-   command "su #{node.conda.user} -c \"#{node.conda.base_dir}/bin/conda update anaconda -y -q\""
+   command "su #{node["conda"]["user"]} -c \"#{node["conda"]["base_dir"]}/bin/conda update anaconda -y -q\""
  end
 
 #
 # Install libraries into the root environment
 #
-for lib in node.conda.default_libs do
+for lib in node["conda"]["default_libs"] do
   execute "install_anconda_default_libs" do
     user "root"
-    command "su #{node.conda.user} -c \"#{node.conda.base_dir}/bin/conda install -q -y #{lib}\""
+    command "su #{node["conda"]["user"]} -c \"#{node["conda"]["base_dir"]}/bin/conda install -q -y #{lib}\""
 # The guard checks if the library is installed. Be careful with library names like 'sphinx' and 'sphinx_rtd_theme' - add space so that 'sphinx' doesnt match both.
-    not_if  "su #{node.conda.user} -c \"#{node.conda.base_dir}/bin/conda list | grep \"#{lib} \"\""
+    not_if  "su #{node["conda"]["user"]} -c \"#{node["conda"]["base_dir"]}/bin/conda list | grep \"#{lib} \"\""
   end
 end
 
 
 execute "create_base" do
   user "root"
-  command "su #{node.conda.user} -c \"#{node.conda.base_dir}/bin/conda create -n #{node.conda.user}\""
-  not_if "test -d #{node.conda.base_dir}/envs/#{node.conda.user}"
+  command "su #{node["conda"]["user"]} -c \"#{node["conda"]["base_dir"]}/bin/conda create -n #{node["conda"]["user"]}\""
+  not_if "test -d #{node["conda"]["base_dir"]}/envs/#{node["conda"]["user"]}"
 end
 
 

--- a/providers/config.rb
+++ b/providers/config.rb
@@ -1,9 +1,9 @@
 action :add do
 
-  ini_file = IniFile.load("#{new_resource.services_file}", :comment => ';#')
-  cluster = "#{node.kagent.cluster}"
-  service = "#{new_resource.service}"
-  role = "#{new_resource.role}"
+  ini_file = IniFile.load("#{new_resource["services_file"]}", :comment => ';#')
+  cluster = "#{node["kagent"]["cluster"]}"
+  service = "#{new_resource["service"]}"
+  role = "#{new_resource["role"]}"
 
 #
 # A section name will have the format: ${CLUSTERNAME}-${SERVICENAME}-${ROLENAME}
@@ -27,12 +27,12 @@ action :add do
     'cluster' => "#{cluster}",
     'service'  => "#{service}",
     'role'  => "#{role}",
-    'web-port' => new_resource.web_port,
-    'stdout-file'  => "#{new_resource.log_file}",
-    'config-file'  => "#{new_resource.config_file}"
-#    'command'  => "#{new_resource.command}",
-#    'command-user'  => "#{new_resource.command_user}",
-#    'command-script'  => "#{new_resource.command_script}",
+    'web-port' => new_resource["web_port"],
+    'stdout-file'  => "#{new_resource["log_file"]}",
+    'config-file'  => "#{new_resource["config_file"]}"
+#    'command'  => "#{new_resource["command"]}",
+#    'command-user'  => "#{new_resource["command_user"]}",
+#    'command-script'  => "#{new_resource["command_script"]}",
 #    'status' => 'Stopped'
   } 
   ini_file.save
@@ -44,7 +44,7 @@ end
 
 
 action :systemd_reload do
-  bash "start-if-not-running-#{new_resource.name}" do
+  bash "start-if-not-running-#{new_resource["name"]}" do
     user "root"
     code <<-EOH
      set -e

--- a/providers/config.rb
+++ b/providers/config.rb
@@ -1,9 +1,9 @@
 action :add do
 
-  ini_file = IniFile.load("#{new_resource["services_file"]}", :comment => ';#')
+  ini_file = IniFile.load("#{new_resource.services_file}", :comment => ';#')
   cluster = "#{node["kagent"]["cluster"]}"
-  service = "#{new_resource["service"]}"
-  role = "#{new_resource["role"]}"
+  service = "#{new_resource.service}"
+  role = "#{new_resource.role}"
 
 #
 # A section name will have the format: ${CLUSTERNAME}-${SERVICENAME}-${ROLENAME}
@@ -27,13 +27,9 @@ action :add do
     'cluster' => "#{cluster}",
     'service'  => "#{service}",
     'role'  => "#{role}",
-    'web-port' => new_resource["web_port"],
-    'stdout-file'  => "#{new_resource["log_file"]}",
-    'config-file'  => "#{new_resource["config_file"]}"
-#    'command'  => "#{new_resource["command"]}",
-#    'command-user'  => "#{new_resource["command_user"]}",
-#    'command-script'  => "#{new_resource["command_script"]}",
-#    'status' => 'Stopped'
+    'web-port' => new_resource.web_port,
+    'stdout-file'  => "#{new_resource.log_file}",
+    'config-file'  => "#{new_resource.config_file}"
   } 
   ini_file.save
   Chef::Log.info "Saved an updated copy of services file at the kagent after updating #{cluster}-#{service}-#{role}"
@@ -44,7 +40,7 @@ end
 
 
 action :systemd_reload do
-  bash "start-if-not-running-#{new_resource["name"]}" do
+  bash "start-if-not-running-#{new_resource.name}" do
     user "root"
     code <<-EOH
      set -e

--- a/providers/keys.rb
+++ b/providers/keys.rb
@@ -25,9 +25,9 @@ end
 
 
 action :generate do
-  homedir = "#{new_resource["homedir"]}"
-  cb_user = "#{new_resource["cb_user"]}"
-  cb_group = "#{new_resource["cb_group"]}"
+  homedir = "#{new_resource.homedir}"
+  cb_user = "#{new_resource.cb_user}"
+  cb_group = "#{new_resource.cb_group}"
 
   bash "generate-ssh-keypair-for-#{homedir}" do
     user cb_user
@@ -41,16 +41,16 @@ end
 
 
 action :return_publickey do
- homedir = "#{new_resource["homedir"]}"
+ homedir = "#{new_resource.homedir}"
  contents = ::IO.read("#{homedir}/.ssh/id_rsa.pub")
 
  raise if contents.empty?
  
  Chef::Log.info "Public key read is: #{contents}"
- cb = "#{new_resource["cb_name"]}"
- recipeName = "#{new_resource["cb_recipe"]}"
- cb_user = "#{new_resource["cb_user"]}"
- cb_group = "#{new_resource["cb_group"]}"
+ cb = "#{new_resource.cb_name}"
+ recipeName = "#{new_resource.cb_recipe}"
+ cb_user = "#{new_resource.cb_user}"
+ cb_group = "#{new_resource.cb_group}"
 
  node.default["#{cb}"]["#{recipeName}"][:public_key] = contents
 
@@ -73,11 +73,11 @@ action :return_publickey do
 end
 
 action :get_publickey do
-  homedir = "#{new_resource["homedir"]}"
-  cb = "#{new_resource["cb_name"]}" 
-  recipeName = "#{new_resource["cb_recipe"]}"
-  cb_user = "#{new_resource["cb_user"]}"
-  cb_group = "#{new_resource["cb_group"]}"
+  homedir = "#{new_resource.homedir}"
+  cb = "#{new_resource.cb_name}" 
+  recipeName = "#{new_resource.cb_recipe}"
+  cb_user = "#{new_resource.cb_user}"
+  cb_group = "#{new_resource.cb_group}"
 
   key_contents = node["#{cb}"]["#{recipeName}"][:public_key]
   Chef::Log.debug "Public key read is: #{key_contents}"

--- a/providers/keys.rb
+++ b/providers/keys.rb
@@ -5,9 +5,9 @@ action :csr do
     code <<-EOF
       set -eo pipefail 
       export PYTHON_EGG_CACHE=/tmp
-      #{node.kagent.certs_dir}/csr.py
+      #{node["kagent"]["certs_dir"]}/csr.py
   EOF
-    not_if { ::File.exists?( "#{node.kagent.keystore_dir}/node_client_truststore.jks" ) }
+    not_if { ::File.exists?( "#{node["kagent"]["keystore_dir"]}/node_client_truststore.jks" ) }
   end
 
 
@@ -15,9 +15,9 @@ action :csr do
     user "root"
     code <<-EOH
       set -eo pipefail 
-      cd #{node.kagent.certs_dir}
-      chown -R root:#{node.kagent.certs_group} #{node.kagent.keystore_dir}
-      chown root:#{node.kagent.certs_group} pub.pem ca_pub.pem priv.key
+      cd #{node["kagent"]["certs_dir"]}
+      chown -R root:#{node["kagent"]["certs_group"]} #{node["kagent"]["keystore_dir"]}
+      chown root:#{node["kagent"]["certs_group"]} pub.pem ca_pub.pem priv.key
     EOH
   end
 
@@ -25,9 +25,9 @@ end
 
 
 action :generate do
-  homedir = "#{new_resource.homedir}"
-  cb_user = "#{new_resource.cb_user}"
-  cb_group = "#{new_resource.cb_group}"
+  homedir = "#{new_resource["homedir"]}"
+  cb_user = "#{new_resource["cb_user"]}"
+  cb_group = "#{new_resource["cb_group"]}"
 
   bash "generate-ssh-keypair-for-#{homedir}" do
     user cb_user
@@ -41,16 +41,16 @@ end
 
 
 action :return_publickey do
- homedir = "#{new_resource.homedir}"
+ homedir = "#{new_resource["homedir"]}"
  contents = ::IO.read("#{homedir}/.ssh/id_rsa.pub")
 
  raise if contents.empty?
  
  Chef::Log.info "Public key read is: #{contents}"
- cb = "#{new_resource.cb_name}"
- recipeName = "#{new_resource.cb_recipe}"
- cb_user = "#{new_resource.cb_user}"
- cb_group = "#{new_resource.cb_group}"
+ cb = "#{new_resource["cb_name"]}"
+ recipeName = "#{new_resource["cb_recipe"]}"
+ cb_user = "#{new_resource["cb_user"]}"
+ cb_group = "#{new_resource["cb_group"]}"
 
  node.default["#{cb}"]["#{recipeName}"][:public_key] = contents
 
@@ -73,11 +73,11 @@ action :return_publickey do
 end
 
 action :get_publickey do
-  homedir = "#{new_resource.homedir}"
-  cb = "#{new_resource.cb_name}" 
-  recipeName = "#{new_resource.cb_recipe}"
-  cb_user = "#{new_resource.cb_user}"
-  cb_group = "#{new_resource.cb_group}"
+  homedir = "#{new_resource["homedir"]}"
+  cb = "#{new_resource["cb_name"]}" 
+  recipeName = "#{new_resource["cb_recipe"]}"
+  cb_user = "#{new_resource["cb_user"]}"
+  cb_group = "#{new_resource["cb_group"]}"
 
   key_contents = node["#{cb}"]["#{recipeName}"][:public_key]
   Chef::Log.debug "Public key read is: #{key_contents}"

--- a/providers/param.rb
+++ b/providers/param.rb
@@ -6,15 +6,15 @@ end
 
 action :add do
 
-  path = "#{new_resource.path}"
-  cookbook = "#{new_resource.cookbook}"
-  recipe = "#{new_resource.recipe}"
-  subrecipe = "#{new_resource.subrecipe}"
-  subsubrecipe = "#{new_resource.subsubrecipe}"
-  param = "#{new_resource.param}"
-  value = "#{new_resource.value}"
-  executing_cookbook = "#{new_resource.executing_cookbook}"
-  executing_recipe = "#{new_resource.executing_recipe}"
+  path = "#{new_resource["path"]}"
+  cookbook = "#{new_resource["cookbook"]}"
+  recipe = "#{new_resource["recipe"]}"
+  subrecipe = "#{new_resource["subrecipe"]}"
+  subsubrecipe = "#{new_resource["subsubrecipe"]}"
+  param = "#{new_resource["param"]}"
+  value = "#{new_resource["value"]}"
+  executing_cookbook = "#{new_resource["executing_cookbook"]}"
+  executing_recipe = "#{new_resource["executing_recipe"]}"
 
 # The result will be written to file in this json format
   if subrecipe.empty?

--- a/providers/param.rb
+++ b/providers/param.rb
@@ -6,15 +6,15 @@ end
 
 action :add do
 
-  path = "#{new_resource["path"]}"
-  cookbook = "#{new_resource["cookbook"]}"
-  recipe = "#{new_resource["recipe"]}"
-  subrecipe = "#{new_resource["subrecipe"]}"
-  subsubrecipe = "#{new_resource["subsubrecipe"]}"
-  param = "#{new_resource["param"]}"
-  value = "#{new_resource["value"]}"
-  executing_cookbook = "#{new_resource["executing_cookbook"]}"
-  executing_recipe = "#{new_resource["executing_recipe"]}"
+  path = "#{new_resource.path}"
+  cookbook = "#{new_resource.cookbook}"
+  recipe = "#{new_resource.recipe}"
+  subrecipe = "#{new_resource.subrecipe}"
+  subsubrecipe = "#{new_resource.subsubrecipe}"
+  param = "#{new_resource.param}"
+  value = "#{new_resource.value}"
+  executing_cookbook = "#{new_resource.executing_cookbook}"
+  executing_recipe = "#{new_resource.executing_recipe}"
 
 # The result will be written to file in this json format
   if subrecipe.empty?

--- a/recipes/anaconda.rb
+++ b/recipes/anaconda.rb
@@ -3,27 +3,27 @@
 # http://blog.cloudera.com/blog/2015/09/how-to-prepare-your-apache-hadoop-cluster-for-pyspark-jobs/
 #
 
-node.override.conda.accept_license = "yes"
+node.override["conda"]["accept_license"] = "yes"
 
 #
 # We would like to install anaconda as user 'glassfish' and then have kagent call it using a sudo script
 #
 
-if node.attribute?(:hops) and node.hops.attribute?(:yarn) and node.hops.yarn.attribute?(:user)
-  node.override.conda.user = node.hops.yarn.user
+if node.attribute?(:hops) and node["hops"].attribute?(:yarn) and node["hops"]["yarn"].attribute?(:user)
+  node.override["conda"]["user"] = node["hops"]["yarn"]["user"]
 end                             
 
-if node.attribute?(:hops) and node.hops.attribute?(:group)
-  node.override.conda.group = node.hops.group
+if node.attribute?(:hops) and node["hops"].attribute?(:group)
+  node.override["conda"]["group"] = node["hops"]["group"]
 end                             
 
-if node.attribute?(:install) and node.install.attribute?(:dir) and node.install.dir.empty? == false
-  node.override.conda.dir = node.install.dir
+if node.attribute?(:install) and node["install"].attribute?(:dir) and node["install"]["dir"].empty? == false
+  node.override["conda"]["dir"] = node["install"]["dir"]
 end  
 
-if node.attribute?(:install) and node.install.attribute?(:user) and node.install.user.empty? == false
-  node.override.conda.user = node.install.user
-  node.override.conda.group = node.install.user
+if node.attribute?(:install) and node["install"].attribute?(:user) and node["install"]["user"].empty? == false
+  node.override["conda"]["user"] = node["install"]["user"]
+  node.override["conda"]["group"] = node["install"]["user"]
 end
 
 include_recipe "conda::install"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -159,7 +159,7 @@ template "#{node.kagent.base_dir}/config.ini" do
   group node.kagent.group
   mode 0600
   variables({
-              :rest_url => "http://#{dashboard_endpoint}/#{node.kagent.dashboard_app}",
+              :rest_url => "http://#{dashboard_endpoint}/",
               :rack => '/default',
               :public_ip => public_ip,
               :private_ip => private_ip,

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -1,6 +1,6 @@
 # ubuntu python-mysqldb package install only works if we first run "apt-get update; apt-get upgrade"
 
-case node.platform_family
+case node["platform_family"]
 when "debian"
   bash "apt_update_install_build_tools" do
     user "root"
@@ -54,43 +54,41 @@ when "rhel"
 end
 
 
-#node.override['poise-python']['options']['pip_version'] = true
-
 #installs python 2
 include_recipe "poise-python"
 # The openssl::upgrade recipe doesn't install openssl-dev/libssl-dev, needed by python-ssl
 # Now using packages in ubuntu/centos.
 #include_recipe "openssl::upgrade"
 
-group node.kagent.group do
+group node["kagent"]["group"] do
   action :create
-  not_if "getent group #{node.kagent.group}"
+  not_if "getent group #{node["kagent"]["group"]}"
 end
 
-group node.kagent.certs_group do
+group node["kagent"]["certs_group"] do
   action :create
-  not_if "getent group #{node.kagent.certs_group}"
+  not_if "getent group #{node["kagent"]["certs_group"]}"
 end
 
-user node.kagent.user do
-  gid node.kagent.group
-  supports :manage_home => true
-  home "/home/#{node.kagent.user}"
+user node["kagent"]["user"] do
+  gid node["kagent"]["group"]
+  manage_home true
+  home "/home/#{node["kagent"]["user"]}"
   action :create
   system true
   shell "/bin/bash"
-  not_if "getent passwd #{node.kagent.user}"
+  not_if "getent passwd #{node["kagent"]["user"]}"
 end
 
-group node.kagent.group do
+group node["kagent"]["group"] do
   action :modify
-  members ["#{node.kagent.user}"]
+  members ["#{node["kagent"]["user"]}"]
   append true
 end
 
-group node.kagent.certs_group do
+group node["kagent"]["certs_group"] do
   action :modify
-  members ["#{node.kagent.user}"]
+  members ["#{node["kagent"]["user"]}"]
   append true
 end
 
@@ -98,8 +96,8 @@ end
 inifile_gem = "inifile-2.0.2.gem"
 cookbook_file "/tmp/#{inifile_gem}" do
   source "#{inifile_gem}"
-  owner node.kagent.user
-  group node.kagent.user
+  owner node["kagent"]["user"]
+  group node["kagent"]["user"]
   mode 0755
   action :create_if_missing
 end
@@ -107,8 +105,8 @@ end
 requests="requests-1.0.3"
 cookbook_file "/tmp/#{requests}.tar.gz" do
   source "#{requests}.tar.gz"
-  owner node.kagent.user
-  group node.kagent.user
+  owner node["kagent"]["user"]
+  group node["kagent"]["user"]
   mode 0755
   action :create_if_missing
 end
@@ -116,8 +114,8 @@ end
 bottle="bottle-0.11.4"
 cookbook_file "/tmp/#{bottle}.tar.gz" do
   source "#{bottle}.tar.gz"
-  owner node.kagent.user
-  group node.kagent.user
+  owner node["kagent"]["user"]
+  group node["kagent"]["user"]
   mode 0755
   action :create_if_missing
 end
@@ -125,16 +123,16 @@ end
 cherry="CherryPy-3.2.2"
 cookbook_file "/tmp/#{cherry}.tar.gz" do
   source "#{cherry}.tar.gz"
-  owner node.kagent.user
-  group node.kagent.user
+  owner node["kagent"]["user"]
+  group node["kagent"]["user"]
   mode 0755
 end
 
 openSsl="pyOpenSSL-0.13"
 cookbook_file "/tmp/#{openSsl}.tar.gz" do
   source "#{openSsl}.tar.gz"
-  owner node.kagent.user
-  group node.kagent.user
+  owner node["kagent"]["user"]
+  group node["kagent"]["user"]
   mode 0755
   action :create_if_missing
 end
@@ -158,8 +156,8 @@ end
 netifaces="netifaces-0.8"
 cookbook_file "/tmp/#{netifaces}.tar.gz" do
   source "#{netifaces}.tar.gz"
-  owner node.kagent.user
-  group node.kagent.user
+  owner node["kagent"]["user"]
+  group node["kagent"]["user"]
   mode 0755
   action :create_if_missing
 end
@@ -167,8 +165,8 @@ end
 ipy="IPy-0.81"
 cookbook_file "/tmp/#{ipy}.tar.gz" do
   source "#{ipy}.tar.gz"
-  owner node.kagent.user
-  group node.kagent.user
+  owner node["kagent"]["user"]
+  group node["kagent"]["user"]
   mode 0755
   action :create_if_missing
 end
@@ -176,8 +174,8 @@ end
 pexpect="pexpect-2.3"
 cookbook_file "/tmp/#{pexpect}.tar.gz" do
   source "#{pexpect}.tar.gz"
-  owner node.kagent.user
-  group node.kagent.user
+  owner node["kagent"]["user"]
+  group node["kagent"]["user"]
   mode 0755
   action :create_if_missing
 end
@@ -228,126 +226,137 @@ bash "make_gemrc_file" do
   not_if "test -f ~/.python_libs_installed"
 end
 
-gem_package "inifile" do
-  source "/tmp/#{inifile_gem}"
+# gem_package "inifile" do
+#   source "/tmp/#{inifile_gem}"
+#   action :install
+# end
+
+chef_gem "inifile" do
   action :install
-end
+end  
 
-directory node.kagent.dir  do
-  owner node.kagent.user
-  group node.kagent.group
+directory node["kagent"]["dir"]  do
+  owner node["kagent"]["user"]
+  group node["kagent"]["group"]
   mode "755"
   action :create
-  not_if { File.directory?("#{node.kagent.dir}") }
+  not_if { File.directory?("#{node["kagent"]["dir"]}") }
 end
 
-directory node.kagent.home do
-  owner node.kagent.user
-  group node.kagent.group
+directory node["kagent"]["home"] do
+  owner node["kagent"]["user"]
+  group node["kagent"]["group"]
   mode "755"
   action :create
 end
 
-directory node.kagent.certs_dir do
-  owner node.kagent.user
-  group node.kagent.certs_group
+directory node["kagent"]["certs_dir"] do
+  owner node["kagent"]["user"]
+  group node["kagent"]["certs_group"]
   mode "750"
   action :create
 end
 
 
-link node.kagent.base_dir do
-  owner node.kagent.user
-  group node.kagent.group
-  to node.kagent.home
+link node["kagent"]["base_dir"] do
+  owner node["kagent"]["user"]
+  group node["kagent"]["group"]
+  to node["kagent"]["home"]
 end
 
 
 
-directory "#{node.kagent.base_dir}/bin" do
-  owner node.kagent.user
-  group node.kagent.group
+directory "#{node["kagent"]["base_dir"]}/bin" do
+  owner node["kagent"]["user"]
+  group node["kagent"]["group"]
   mode "755"
   action :create
 end
 
-directory node.kagent.keystore_dir do
-  owner node.kagent.user
-  group node.kagent.group
+directory node["kagent"]["keystore_dir"] do
+  owner node["kagent"]["user"]
+  group node["kagent"]["group"]
   mode "755"
   action :create
 end
 
-file node.default.kagent.services do
-  owner node.kagent.user
-  group node.kagent.group
+file node["kagent"]["services"] do
+  owner node["kagent"]["user"]
+  group node["kagent"]["group"]
   mode "755"
   action :create_if_missing
 end
 
-if node.ntp.install == "true"
+if node["ntp"]["install"] == "true"
   include_recipe "ntp::default"
 end
 
-require 'resolv'
-my_hostname = Resolv.getname my_private_ip()
+#require 'resolv'
+#my_hostname = Resolv.getname my_private_ip()
 
-template "#{node.kagent.base_dir}/agent.py" do
+my_hostname = node['hostname']
+if node["kagent"].attribute?("hostname") then
+ my_hostname = node["kagent"]["hostname"]
+end
+
+
+
+template "#{node["kagent"]["base_dir"]}/agent.py" do
   source "agent.py.erb"
-  owner node.kagent.user
-  group node.kagent.group
+  owner node["kagent"]["user"]
+  group node["kagent"]["group"]
   mode 0710
   variables({
-              :kstore => "#{node.kagent.keystore_dir}/#{my_hostname}__kstore.jks",
-              :tstore => "#{node.kagent.keystore_dir}/#{my_hostname}__tstore.jks"
+              :kstore => "#{node["kagent"]["keystore_dir"]}/#{my_hostname}__kstore.jks",
+              :tstore => "#{node["kagent"]["keystore_dir"]}/#{my_hostname}__tstore.jks"
             })
 end
 
 
-template"#{node.kagent.certs_dir}/csr.py" do
+template"#{node["kagent"]["certs_dir"]}/csr.py" do
   source "csr.py.erb"
-  owner node.kagent.user
-  group node.kagent.certs_group
+  owner node["kagent"]["user"]
+  group node["kagent"]["certs_group"]
   mode 0710
   variables({
-              :kstore => "#{node.kagent.keystore_dir}/#{my_hostname}__kstore.jks",
-              :tstore => "#{node.kagent.keystore_dir}/#{my_hostname}__tstore.jks"
+              :kstore => "#{node["kagent"]["keystore_dir"]}/#{my_hostname}__kstore.jks",
+              :tstore => "#{node["kagent"]["keystore_dir"]}/#{my_hostname}__tstore.jks"
             })
 end
 
 
 ['start-agent.sh', 'stop-agent.sh', 'restart-agent.sh', 'get-pid.sh'].each do |script|
   Chef::Log.info "Installing #{script}"
-  template "#{node.kagent.base_dir}/bin/#{script}" do
+  template "#{node["kagent"]["base_dir"]}/bin/#{script}" do
     source "#{script}.erb"
-    owner node.kagent.user
-    group node.kagent.group
+    owner node["kagent"]["user"]
+    group node["kagent"]["group"]
     mode 0750
   end
 end 
 
 ['services'].each do |conf|
   Chef::Log.info "Installing #{conf}"
-  template "#{node.kagent.base_dir}/#{conf}" do
+  template "#{node["kagent"]["base_dir"]}/#{conf}" do
     source "#{conf}.erb"
-    owner node.kagent.user
-    group node.kagent.group
+    owner node["kagent"]["user"]
+    group node["kagent"]["group"]
     mode 0644
   end
 end
 
 ['start-service.sh', 'stop-service.sh', 'restart-service.sh', 'status-service.sh'].each do |script|
-  template  "#{node.kagent.base_dir}/bin/#{script}" do
+  template  "#{node["kagent"]["base_dir"]}/bin/#{script}" do
     source "#{script}.erb"
     owner "root"
-    group node.kagent.group
+    group node["kagent"]["group"]
     mode 0750
   end
 end
 
 
 # set_my_hostname
-if node.vagrant === "true" || node.vagrant == true 
+if node["vagrant"] === "true" || node["vagrant"] == true 
     node[:kagent][:default][:private_ips].each_with_index do |ip, index| 
       hostsfile_entry "#{ip}" do
         hostname  "dn#{index}"
@@ -358,18 +367,18 @@ if node.vagrant === "true" || node.vagrant == true
 end
 
 
-template "#{node.kagent.home}/bin/conda.sh" do
+template "#{node["kagent"]["home"]}/bin/conda.sh" do
   source "conda.sh.erb"
-  owner node.kagent.user
-  group node.kagent.group
+  owner node["kagent"]["user"]
+  group node["kagent"]["group"]
   mode "755"
   action :create
 end
 
-template "#{node.kagent.home}/bin/anaconda_env.sh" do
+template "#{node["kagent"]["home"]}/bin/anaconda_env.sh" do
   source "anaconda_env.sh.erb"
-  owner node.kagent.user
-  group node.kagent.group
+  owner node["kagent"]["user"]
+  group node["kagent"]["group"]
   mode "755"
   action :create
 end
@@ -381,16 +390,16 @@ template "/etc/sudoers.d/kagent" do
   group "root"
   mode "0440"
   variables({
-                :user => node.kagent.user,
-                :conda =>  "#{node.kagent.base_dir}/bin/conda.sh",
-                :anaconda =>  "#{node.kagent.base_dir}/bin/anaconda_env.sh",
-                :start => "#{node.kagent.base_dir}/bin/start-service.sh",
-                :stop => "#{node.kagent.base_dir}/bin/stop-service.sh",
-                :restart => "#{node.kagent.base_dir}/bin/restart-service.sh",
-                :status => "#{node.kagent.base_dir}/bin/status-service.sh",
-                :startall => "#{node.kagent.base_dir}/bin/start-all-local-services.sh",
-                :stopall => "#{node.kagent.base_dir}/bin/shutdown-all-local-services.sh",
-                :statusall => "#{node.kagent.base_dir}/bin/status-all-local-services.sh"                
+                :user => node["kagent"]["user"],
+                :conda =>  "#{node["kagent"]["base_dir"]}/bin/conda.sh",
+                :anaconda =>  "#{node["kagent"]["base_dir"]}/bin/anaconda_env.sh",
+                :start => "#{node["kagent"]["base_dir"]}/bin/start-service.sh",
+                :stop => "#{node["kagent"]["base_dir"]}/bin/stop-service.sh",
+                :restart => "#{node["kagent"]["base_dir"]}/bin/restart-service.sh",
+                :status => "#{node["kagent"]["base_dir"]}/bin/status-service.sh",
+                :startall => "#{node["kagent"]["base_dir"]}/bin/start-all-local-services.sh",
+                :stopall => "#{node["kagent"]["base_dir"]}/bin/shutdown-all-local-services.sh",
+                :statusall => "#{node["kagent"]["base_dir"]}/bin/status-all-local-services.sh"                
               })
   action :create
 end  

--- a/recipes/purge.rb
+++ b/recipes/purge.rb
@@ -31,19 +31,19 @@ end
 }
 
 # Remove the MySQL binaries and MySQL Cluster data directories
-directory node.kagent.base_dir do
+directory node["kagent"]["base_dir"] do
   recursive true
   action :delete
   ignore_failure true
 end
 
-directory node.kagent.home do
+directory node["kagent"]["home"] do
   recursive true
   action :delete
   ignore_failure true
 end
 
-directory node.kagent.certs_dir do
+directory node["kagent"]["certs_dir"] do
   recursive true
   action :delete
   ignore_failure true

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -1,6 +1,6 @@
 actions :add, :systemd_reload
 
-attribute :services_file, :kind_of => String, :default => node.kagent.services
+attribute :services_file, :kind_of => String, :default => node["kagent"]["services"]
 attribute :role, :kind_of => String, :name_attribute => true, :required => true
 attribute :service, :kind_of => String, :required => true
 attribute :web_port, :kind_of => Integer, :default => 0

--- a/templates/default/agent.py.erb
+++ b/templates/default/agent.py.erb
@@ -58,7 +58,7 @@ CA_FILE = "<%= node[:kagent][:certs_dir] %>/ca_pub.pem"
 KEY_FILE = "<%= node[:kagent][:certs_dir] %>/priv.key"
 SERVER_KEYSTORE = "<%= @kstore %>"
 SERVER_TRUSTSTORE = "<%= @tstore %>"
-CLIENT_TRUSTSTORE = "<%= node.kagent.keystore_dir %>/node_client_truststore.jks"
+CLIENT_TRUSTSTORE = "<%= node[:kagent][:keystore_dir] %>/node_client_truststore.jks"
 
 global states
 states = {}
@@ -746,8 +746,8 @@ class SSLCherryPy(ServerAdapter):
         # cherrypy.config.update({
         # 'environment': 'production',
         # 'log.screen': False,
-        # 'log.access_file': "<%= node.kagent.base_dir %>/access.log",
-        # 'log.error_file': "<%= node.kagent.base_dir %>/error.log",
+        # 'log.access_file': "<%= node[:kagent][:base_dir] %>/access.log",
+        # 'log.error_file': "<%= node[:kagent][:base_dir] %>/error.log",
         # 'server.socket_host': '0.0.0.0',
         # 'server.socket_port': agent_restport,
         # 'tools.caching.on': False,

--- a/templates/default/anaconda_env.sh.erb
+++ b/templates/default/anaconda_env.sh.erb
@@ -21,7 +21,7 @@ if [ "$OP" == "CLONE" ] ; then
 fi
 
 function exists() {
-    su $EXEC_AS_USER -c "<%= node.conda.base_dir %>/bin/conda info --envs | grep '^${PROJECT} '"
+    su $EXEC_AS_USER -c "<%= node["conda"]["base_dir"] %>/bin/conda info --envs | grep '^${PROJECT} '"
     return $?
 }
 
@@ -30,20 +30,20 @@ if [ "$OP" == "CREATE" ] ; then
     if [ $? -eq 0 ] ; then 
        exit 0
     fi
-    su $EXEC_AS_USER -c "<%= node.conda.base_dir %>/bin/conda create -n $PROJECT python=$PYTHON_VERSION -y -q $OFFLINE"
+    su $EXEC_AS_USER -c "<%= node["conda"]["base_dir"] %>/bin/conda create -n $PROJECT python=$PYTHON_VERSION -y -q $OFFLINE"
 elif [ "$OP" == "LIST_ENVS" ] ; then
-  su $EXEC_AS_USER -c "<%= node.conda.base_dir %>/bin/conda env list --json > /tmp/conda_envs.json"    
+  su $EXEC_AS_USER -c "<%= node["conda"]["base_dir"] %>/bin/conda env list --json > /tmp/conda_envs.json"    
 elif [ "$OP" == "LIST" ] ; then
-  su $EXEC_AS_USER -c "<%= node.conda.base_dir %>/bin/conda list -n $PROJECT --json > /tmp/${PROJECT}__conda_list.json"
+  su $EXEC_AS_USER -c "<%= node["conda"]["base_dir"] %>/bin/conda list -n $PROJECT --json > /tmp/${PROJECT}__conda_list.json"
 elif [ "$OP" == "CLONE" ] ; then
-  su $EXEC_AS_USER -c "<%= node.conda.base_dir %>/bin/conda create -n $PROJECT --clone $CLONE -y -q $OFFLINE"
+  su $EXEC_AS_USER -c "<%= node["conda"]["base_dir"] %>/bin/conda create -n $PROJECT --clone $CLONE -y -q $OFFLINE"
 elif [ "$OP" == "REMOVE" ] ; then
     exists    # If the env has already been removed, return OK
     if [ $? -ne 0 ] ; then
        echo "Cannot remove environment that doesn't exist"
        exit 0
     fi
-  su $EXEC_AS_USER -c "<%= node.conda.base_dir %>/bin/conda-env remove -n $PROJECT -y -q"
+  su $EXEC_AS_USER -c "<%= node["conda"]["base_dir"] %>/bin/conda-env remove -n $PROJECT -y -q"
 else
     exit -1
 fi

--- a/templates/default/conda.sh.erb
+++ b/templates/default/conda.sh.erb
@@ -36,7 +36,7 @@ LIB="${1}${VERSION}"
 
 
 function exists() {
-    su $EXEC_AS_USER -c "<%= node.conda.base_dir %>/bin/conda list -n $PROJECT | grep '^${LIB_NAME} '"
+    su $EXEC_AS_USER -c "<%= node["conda"]["base_dir"] %>/bin/conda list -n $PROJECT | grep '^${LIB_NAME} '"
     return $?
 }
 
@@ -48,17 +48,17 @@ res=0
 if [ "$OP" == "INSTALL" ] ; then
   exists
   if [ $? -ne 0 ] ; then
-      su $EXEC_AS_USER -c "<%= node.conda.base_dir %>/bin/conda install -n $PROJECT -q -y $CHANNEL $LIB"
+      su $EXEC_AS_USER -c "<%= node["conda"]["base_dir"] %>/bin/conda install -n $PROJECT -q -y $CHANNEL $LIB"
   fi
 elif [ "$OP" == "UPGRADE" ] ; then
   exists
   if [ $? -eq 0 ] ; then
-      su $EXEC_AS_USER -c "<%= node.conda.base_dir %>/bin/conda upgrade -n $PROJECT -q -y $CHANNEL $LIB"
+      su $EXEC_AS_USER -c "<%= node["conda"]["base_dir"] %>/bin/conda upgrade -n $PROJECT -q -y $CHANNEL $LIB"
   fi
 elif [ "$OP" == "UNINSTALL" ] ; then
   exists
   if [ $? -ne 0 ] ; then
-      su $EXEC_AS_USER -c "<%= node.conda.base_dir %>/bin/conda remove -n $PROJECT -q -y $CHANNEL $LIB"
+      su $EXEC_AS_USER -c "<%= node["conda"]["base_dir"] %>/bin/conda remove -n $PROJECT -q -y $CHANNEL $LIB"
   fi
 else
   res=-5

--- a/templates/default/config.ini.erb
+++ b/templates/default/config.ini.erb
@@ -1,9 +1,9 @@
 [server]
 url = <%= @rest_url %>
-path-login: <%= node[:kagent][:dashboard][:api][:login] %>
-path-register: <%= node[:kagent][:dashboard][:api][:register] %>
-path-heartbeat: <%= node[:kagent][:dashboard][:api][:heartbeat] %>
-path-alert: <%= node[:kagent][:dashboard][:api][:alert] %>
+path-login: <%= node[:kagent][:dashboard_app] %>/<%= node[:kagent][:dashboard][:api][:login] %>
+path-register: hopsworks-ca/<%= node[:kagent][:dashboard][:api][:register] %>
+path-heartbeat: <%= node[:kagent][:dashboard_app] %>/<%= node[:kagent][:dashboard][:api][:heartbeat] %>
+path-alert: <%= node[:kagent][:dashboard_app] %>/<%= node[:kagent][:dashboard][:api][:alert] %>
 username = <%= node[:kagent][:dashboard][:user] %>
 password = <%= node[:kagent][:dashboard][:password] %>
 

--- a/templates/default/csr.py.erb
+++ b/templates/default/csr.py.erb
@@ -191,7 +191,7 @@ CA_FILE = "<%= node[:kagent][:certs_dir] %>/ca_pub.pem"
 KEY_FILE = "<%= node[:kagent][:certs_dir] %>/priv.key"
 SERVER_KEYSTORE = "<%= @kstore %>"
 SERVER_TRUSTSTORE = "<%= @tstore %>"
-CLIENT_TRUSTSTORE = "<%= node.kagent.keystore_dir %>/node_client_truststore.jks"
+CLIENT_TRUSTSTORE = "<%= node["kagent"]["keystore_dir"] %>/node_client_truststore.jks"
 
 # reading config
 try:

--- a/templates/default/kagent.service.erb
+++ b/templates/default/kagent.service.erb
@@ -3,7 +3,7 @@ Description = Kagent, monitors/controls Hops services
 After = syslog.target network.target remote-fs.target
 
 [Service]
-User = <%= node.kagent.user %>
+User = <%= node["kagent"]["user"] %>
 
 PIDFile = <%= node[:kagent][:pid_file] %>
 ExecStart = <%= "#{node[:kagent][:base_dir]}/bin/start-agent.sh" %>

--- a/templates/default/keystore.sh.erb
+++ b/templates/default/keystore.sh.erb
@@ -8,22 +8,22 @@ cd <%= @directory %>
 rm -f <%= node['hostname'] %>__kstore.jks <%= node['hostname'] %>__tstore.jks
 cd ..
 rm -f <%= node['hostname'] %>__kstore.jks <%= node['hostname'] %>__tstore.jks cert_and_key.p12
-chown <%= node.kagent.user %> pub.pem 
-chown <%= node.kagent.user %> ca_pub.pem 
-chown <%= node.kagent.user %> priv.key
+chown <%= node["kagent"]["user"] %> pub.pem 
+chown <%= node["kagent"]["user"] %> ca_pub.pem 
+chown <%= node["kagent"]["user"] %> priv.key
 
 if [ -e "ca_pub.pem" ] && [ -e "priv.key" ] && [ -e "pub.pem" ] ; then
 	KEYSTOREPW=<%= @keystorepass %>
 
-su <%= node.kagent.user %> -c "openssl pkcs12 -export -in pub.pem -inkey priv.key -out cert_and_key.p12 -name <%= node['hostname'] %> -CAfile ca_pub.pem -caname root -password pass:$KEYSTOREPW"
-su <%= node.kagent.user %> -c "keytool -importkeystore -destkeystore node_server_keystore.jks -srckeystore cert_and_key.p12 -srcstoretype PKCS12 -alias <%= node['hostname'] %> -srcstorepass $KEYSTOREPW -deststorepass $KEYSTOREPW -destkeypass $KEYSTOREPW"
-su <%= node.kagent.user %> -c "keytool -import -noprompt -trustcacerts -alias CARoot -file ca_pub.pem -keystore node_server_keystore.jks -srcstorepass $KEYSTOREPW -deststorepass $KEYSTOREPW -destkeypass $KEYSTOREPW"
-su <%= node.kagent.user %> -c "keytool -import -noprompt -trustcacerts -alias CARoot -file ca_pub.pem -keystore node_server_truststore.jks -srcstorepass $KEYSTOREPW -deststorepass $KEYSTOREPW -destkeypass $KEYSTOREPW"
+su <%= node["kagent"]["user"] %> -c "openssl pkcs12 -export -in pub.pem -inkey priv.key -out cert_and_key.p12 -name <%= node['hostname'] %> -CAfile ca_pub.pem -caname root -password pass:$KEYSTOREPW"
+su <%= node["kagent"]["user"] %> -c "keytool -importkeystore -destkeystore node_server_keystore.jks -srckeystore cert_and_key.p12 -srcstoretype PKCS12 -alias <%= node['hostname'] %> -srcstorepass $KEYSTOREPW -deststorepass $KEYSTOREPW -destkeypass $KEYSTOREPW"
+su <%= node["kagent"]["user"] %> -c "keytool -import -noprompt -trustcacerts -alias CARoot -file ca_pub.pem -keystore node_server_keystore.jks -srcstorepass $KEYSTOREPW -deststorepass $KEYSTOREPW -destkeypass $KEYSTOREPW"
+su <%= node["kagent"]["user"] %> -c "keytool -import -noprompt -trustcacerts -alias CARoot -file ca_pub.pem -keystore node_server_truststore.jks -srcstorepass $KEYSTOREPW -deststorepass $KEYSTOREPW -destkeypass $KEYSTOREPW"
 cp node_server_keystore.jks "<%= @directory %>/<%= node['hostname'] %>__kstore.jks"
 cp node_server_truststore.jks "<%= @directory %>/<%= node['hostname'] %>__tstore.jks"
 cp node_server_truststore.jks <%= @directory %>/node_client_truststore.jks
 
-chown <%= node.kagent.user %>:<%= node.kagent.certs_group %> <%= @directory %>/*.jks
+chown <%= node["kagent"]["user"] %>:<%= node["kagent"]["certs_group"] %> <%= @directory %>/*.jks
 rm node_server_keystore.jks node_server_truststore.jks cert_and_key.p12
 chmod 640 <%= @directory %>/*
 chmod 750 <%= @directory %>

--- a/templates/default/shutdown-all-local-services.sh.erb
+++ b/templates/default/shutdown-all-local-services.sh.erb
@@ -45,7 +45,7 @@ export LC_ALL=en_US.UTF-8
 stop()
 {
 if [[ $services == *"$active"* ]] ; then
- sudo <%= node.kagent.base_dir %>/bin/status-service.sh $active > /dev/null
+ sudo <%= node["kagent"]["base_dir"] %>/bin/status-service.sh $active > /dev/null
  if [ $? -eq 0 ] ; then
    echo -e "Stopping ${active} ...."
    sudo service $active stop
@@ -63,7 +63,7 @@ fi
 
 
 # Check which services are installed on this server
-services=$(grep role <%= node.kagent.base_dir %>/services | perl -p -e "s/role = //g" | perl -p -e "s/\n/ /g") 2>&1 > /dev/null
+services=$(grep role <%= node["kagent"]["base_dir"] %>/services | perl -p -e "s/role = //g" | perl -p -e "s/\n/ /g") 2>&1 > /dev/null
 services="kagent $services glassfish-domain1"
 
 echo -e ""

--- a/templates/default/start-all-local-services.sh.erb
+++ b/templates/default/start-all-local-services.sh.erb
@@ -7,7 +7,7 @@ export LC_ALL=en_US.UTF-8
 start()
 {
 if [[ $services == *"$active"* ]] ; then
- sudo <%= node.kagent.base_dir %>/bin/status-service.sh $active > /dev/null
+ sudo <%= node["kagent"]["base_dir"] %>/bin/status-service.sh $active > /dev/null
  if [ $? -ne 0 ] ; then
    echo -e "Starting ${active} ...."
    sudo service $active start 2>&1 > /dev/null
@@ -31,7 +31,7 @@ fi
 }
 
 # Check which services are installed on this server
-services=$(grep role <%= node.kagent.base_dir %>/services | perl -p -e "s/role = //g" | perl -p -e "s/\n/ /g") 2>&1 > /dev/null
+services=$(grep role <%= node["kagent"]["base_dir"] %>/services | perl -p -e "s/role = //g" | perl -p -e "s/\n/ /g") 2>&1 > /dev/null
 services="kagent $services glassfish-domain1"
 
 echo -e ""

--- a/templates/default/status-all-local-services.sh.erb
+++ b/templates/default/status-all-local-services.sh.erb
@@ -19,7 +19,7 @@ fi
 
 
 # Check which services are installed on this server
-services=$(grep role <%= node.kagent.base_dir %>/services | perl -p -e "s/role = //g" | perl -p -e "s/\n/ /g") 2>&1 > /dev/null
+services=$(grep role <%= node["kagent"]["base_dir"] %>/services | perl -p -e "s/role = //g" | perl -p -e "s/\n/ /g") 2>&1 > /dev/null
 services="kagent $services glassfish-domain1"
 
 echo -e ""


### PR DESCRIPTION
We need to run kagent:default before starting all Hadoop services: nn, rm, dn, nm, etc. This PR enables that.
This PR also re-writes the code to support the Chef13 syntax where node.kagent.attr is no longer allowed. It is now: node["kagent"]["attr"].